### PR TITLE
Only onsider first valid link

### DIFF
--- a/GeneanetForGramps.py
+++ b/GeneanetForGramps.py
@@ -1331,6 +1331,9 @@ class GPerson(GBase):
                                     pref = a.xpath('attribute::href')[0]
                                 except:
                                     pref = ""
+                                # only consider first valid link instead of overwriting with eg "seigneur de XYZ" or "propriétaire à XYZ":
+                                if pname and pref:
+                                    break
 
                         if verbosity >= 1:
                            print(_("Parent name: %s (%s)")%(pname,ROOTURL+pref))


### PR DESCRIPTION
Else we would overwrite with eg "seigneur de XYZ" or "propriétaire à XYZ" Eg: importing the following fail w/o that change:
https://gw.geneanet.org/zardoz?lang=fr&p=simonde&n=d+agulhac&oc=1 https://gw.geneanet.org/olivierauthier?lang=fr&p=marie+charlotte&n=andrault

Fix #37